### PR TITLE
Add project management workflows

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -1,0 +1,113 @@
+name: Auto Add to Project
+
+# Adds every new issue to Project #5 and sets initial status:
+# - Bug → Analysis (reactive, needs immediate triage)
+# - Everything else → Planning (future work, awaiting scoping)
+#
+# The built-in project workflow "Item added to project" also sets Planning,
+# but this workflow overrides Bugs to Analysis after the add.
+#
+# Authentication: GitHub App (ilm-project-bot)
+# Trigger: new issue opened in any org repo
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      # Generate a short-lived token from the GitHub App
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.ILM_PROJECT_BOT_APP_ID }}
+          private-key: ${{ secrets.ILM_PROJECT_BOT_PRIVATE_KEY }}
+          owner: OmnitrustILM
+
+      # Add the issue to Project #5
+      - name: Add issue to project
+        uses: actions/add-to-project@v1
+        with:
+          project-url: https://github.com/orgs/OmnitrustILM/projects/5
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      # Set initial status based on issue type:
+      # Bugs → Analysis (needs triage), everything else → Planning (future work)
+      - name: Set initial status
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_TYPE: ${{ github.event.issue.issue_type.name }}
+        run: |
+          # Determine initial status
+          if [ "$ISSUE_TYPE" = "Bug" ]; then
+            STATUS="Analysis"
+          else
+            STATUS="Planning"
+          fi
+
+          echo "Issue type: ${ISSUE_TYPE:-unknown}"
+          echo "Setting status to: $STATUS"
+
+          # Wait briefly for add-to-project to complete
+          sleep 3
+
+          # Get the project item ID for this issue
+          ITEM_ID=$(gh api graphql -f query='
+            query($url: URI!) {
+              resource(url: $url) {
+                ... on Issue {
+                  projectItems(first: 10) {
+                    nodes {
+                      id
+                      project { id }
+                    }
+                  }
+                }
+              }
+            }' -f url="$ISSUE_URL" \
+            --jq '.data.resource.projectItems.nodes[] | select(.project.id == "PVT_kwDOB4ppKM4AlVOh") | .id')
+
+          if [ -z "$ITEM_ID" ] || [ "$ITEM_ID" = "null" ]; then
+            echo "::warning::Issue not found in project. It may not have been added yet."
+            exit 0
+          fi
+
+          # Get Status field ID and the target option ID
+          STATUS_FIELD=$(gh api graphql -f query='
+            { organization(login: "OmnitrustILM") {
+              projectV2(number: 5) {
+                field(name: "Status") {
+                  ... on ProjectV2SingleSelectField {
+                    id
+                    options { id name }
+                  }
+                }
+              }
+            } }' --jq '.data.organization.projectV2.field')
+
+          FIELD_ID=$(echo "$STATUS_FIELD" | jq -r '.id')
+          OPTION_ID=$(echo "$STATUS_FIELD" | jq -r ".options[] | select(.name == \"$STATUS\") | .id")
+
+          if [ -z "$OPTION_ID" ] || [ "$OPTION_ID" = "null" ]; then
+            echo "::warning::Status option '$STATUS' not found in project field."
+            exit 0
+          fi
+
+          # Set the status on the project item
+          gh api graphql -f query="
+            mutation {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: \"PVT_kwDOB4ppKM4AlVOh\"
+                itemId: \"$ITEM_ID\"
+                fieldId: \"$FIELD_ID\"
+                value: { singleSelectOptionId: \"$OPTION_ID\" }
+              }) {
+                projectV2Item { id }
+              }
+            }"
+
+          echo "Status set to $STATUS for issue $ISSUE_URL"

--- a/.github/workflows/auto-set-fields-from-form.yml
+++ b/.github/workflows/auto-set-fields-from-form.yml
@@ -44,12 +44,13 @@ jobs:
           ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
         run: |
           # --- Extract form field values ---
-          # GitHub YAML forms render as: ### Field Label\n\nValue
-          # We grab the line after the heading. "_No response_" means user skipped it.
+          # GitHub YAML forms render as: ### Field Label\n\n(blank line)\nValue
+          # grep -A2 captures heading + blank line + value, tail -1 gets the value.
+          # "_No response_" means user skipped an optional field.
 
-          SEVERITY=$(echo "$ISSUE_BODY" | grep -A1 '### Severity' | tail -1 | xargs 2>/dev/null || echo "")
-          MODULE=$(echo "$ISSUE_BODY" | grep -A1 '### Module' | tail -1 | xargs 2>/dev/null || echo "")
-          VERSION=$(echo "$ISSUE_BODY" | grep -A1 '### Version Number' | tail -1 | xargs 2>/dev/null || echo "")
+          SEVERITY=$(echo "$ISSUE_BODY" | grep -A2 '### Severity' | tail -1 | xargs 2>/dev/null || echo "")
+          MODULE=$(echo "$ISSUE_BODY" | grep -A2 '### Module' | tail -1 | xargs 2>/dev/null || echo "")
+          VERSION=$(echo "$ISSUE_BODY" | grep -A2 '### Version Number' | tail -1 | xargs 2>/dev/null || echo "")
 
           # Clear "_No response_" placeholders (GitHub sets this when optional fields are skipped)
           [ "$SEVERITY" = "_No response_" ] && SEVERITY=""
@@ -123,7 +124,7 @@ jobs:
               } }" --jq '.data.organization.projectV2.field')
 
             local field_id=$(echo "$field_data" | jq -r '.id')
-            local option_id=$(echo "$field_data" | jq -r ".options[] | select(.name == \"$value\") | .id")
+            local option_id=$(echo "$field_data" | jq -r --arg name "$value" '.options[] | select(.name == $name) | .id')
 
             if [ -n "$option_id" ] && [ "$option_id" != "null" ]; then
               gh api graphql -f query="

--- a/.github/workflows/auto-set-fields-from-form.yml
+++ b/.github/workflows/auto-set-fields-from-form.yml
@@ -1,0 +1,151 @@
+name: Auto Set Fields from Form
+
+# Parses structured form data from Bug/Vulnerability/Release templates
+# and sets the corresponding project custom fields.
+#
+# Fields parsed:
+# - Severity (Bug, Vulnerability) → project Severity field
+# - Module (Bug, optional) → project Module field
+# - Version Number (Release) → project Version field
+#
+# Vulnerability defaults (when `vulnerability` label present):
+# - Severity → Critical (if reporter didn't set it)
+# - Priority → High (if empty)
+#
+# Defensive parsing: if extraction fails, fields are left empty.
+# The triage skill catches missing fields later.
+#
+# Authentication: GitHub App (ilm-project-bot)
+# Trigger: new issue opened in any org repo
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  parse-and-set:
+    runs-on: ubuntu-latest
+    steps:
+      # Generate a short-lived token from the GitHub App
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.ILM_PROJECT_BOT_APP_ID }}
+          private-key: ${{ secrets.ILM_PROJECT_BOT_PRIVATE_KEY }}
+          owner: OmnitrustILM
+
+      # Parse form fields from issue body and set project fields
+      - name: Parse form fields and set project values
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
+        run: |
+          # --- Extract form field values ---
+          # GitHub YAML forms render as: ### Field Label\n\nValue
+          # We grab the line after the heading. "_No response_" means user skipped it.
+
+          SEVERITY=$(echo "$ISSUE_BODY" | grep -A1 '### Severity' | tail -1 | xargs 2>/dev/null || echo "")
+          MODULE=$(echo "$ISSUE_BODY" | grep -A1 '### Module' | tail -1 | xargs 2>/dev/null || echo "")
+          VERSION=$(echo "$ISSUE_BODY" | grep -A1 '### Version Number' | tail -1 | xargs 2>/dev/null || echo "")
+
+          # Clear "_No response_" placeholders (GitHub sets this when optional fields are skipped)
+          [ "$SEVERITY" = "_No response_" ] && SEVERITY=""
+          [ "$MODULE" = "_No response_" ] && MODULE=""
+          [ "$VERSION" = "_No response_" ] && VERSION=""
+
+          # --- Apply vulnerability defaults ---
+          # If vulnerability label is present, default Severity to Critical and Priority to High
+          PRIORITY=""
+          if echo "$ISSUE_LABELS" | grep -q "vulnerability"; then
+            if [ -z "$SEVERITY" ]; then
+              SEVERITY="Critical"
+              echo "Vulnerability without Severity — defaulting to Critical"
+            fi
+            PRIORITY="High"
+            echo "Vulnerability — defaulting Priority to High"
+          fi
+
+          echo "Parsed — Severity: ${SEVERITY:-empty}, Module: ${MODULE:-empty}, Version: ${VERSION:-empty}, Priority: ${PRIORITY:-empty}"
+
+          # Skip if nothing to set
+          if [ -z "$SEVERITY" ] && [ -z "$MODULE" ] && [ -z "$PRIORITY" ] && [ -z "$VERSION" ]; then
+            echo "No fields to set, exiting."
+            exit 0
+          fi
+
+          # --- Wait for add-to-project workflow to complete ---
+          sleep 5
+
+          # --- Get project item ID for this issue ---
+          ITEM_ID=$(gh api graphql -f query='
+            query($url: URI!) {
+              resource(url: $url) {
+                ... on Issue {
+                  projectItems(first: 10) {
+                    nodes {
+                      id
+                      project { id }
+                    }
+                  }
+                }
+              }
+            }' -f url="$ISSUE_URL" \
+            --jq '.data.resource.projectItems.nodes[] | select(.project.id == "PVT_kwDOB4ppKM4AlVOh") | .id')
+
+          if [ -z "$ITEM_ID" ] || [ "$ITEM_ID" = "null" ]; then
+            echo "::warning::Issue not yet in project, skipping field set."
+            exit 0
+          fi
+
+          # --- Helper function to set a single-select field ---
+          set_field() {
+            local field_name=$1
+            local value=$2
+
+            if [ -z "$value" ]; then
+              return
+            fi
+
+            # Get field ID and option ID
+            local field_data=$(gh api graphql -f query="
+              { organization(login: \"OmnitrustILM\") {
+                projectV2(number: 5) {
+                  field(name: \"$field_name\") {
+                    ... on ProjectV2SingleSelectField {
+                      id
+                      options { id name }
+                    }
+                  }
+                }
+              } }" --jq '.data.organization.projectV2.field')
+
+            local field_id=$(echo "$field_data" | jq -r '.id')
+            local option_id=$(echo "$field_data" | jq -r ".options[] | select(.name == \"$value\") | .id")
+
+            if [ -n "$option_id" ] && [ "$option_id" != "null" ]; then
+              gh api graphql -f query="
+                mutation {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: \"PVT_kwDOB4ppKM4AlVOh\"
+                    itemId: \"$ITEM_ID\"
+                    fieldId: \"$field_id\"
+                    value: { singleSelectOptionId: \"$option_id\" }
+                  }) {
+                    projectV2Item { id }
+                  }
+                }"
+              echo "Set $field_name to $value"
+            else
+              # Defensive: value not found in field options — skip silently
+              echo "::warning::Could not find option '$value' for field '$field_name' — skipping."
+            fi
+          }
+
+          # --- Set each field independently (one failure doesn't block others) ---
+          set_field "Severity" "$SEVERITY"
+          set_field "Module" "$MODULE"
+          set_field "Priority" "$PRIORITY"
+          set_field "Version" "$VERSION"

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -71,7 +71,7 @@ jobs:
                 echo "::warning::Failed to sync label '$name' to $repo"
                 REPO_FAILED=$((REPO_FAILED + 1))
               fi
-            done < <(yq eval '.[]' -o=json labels.yml)
+            done < <(yq eval '.[]' -o=json -I=0 labels.yml)
 
             if [ "$REPO_FAILED" -gt 0 ]; then
               FAILED=$((FAILED + REPO_FAILED))

--- a/.github/workflows/post-release-stamping.yml
+++ b/.github/workflows/post-release-stamping.yml
@@ -1,0 +1,152 @@
+name: Post-Release Version Stamping
+
+# When a GitHub Release is published, stamps the Version field on
+# closed Done issues in that repo that don't have a Version set.
+#
+# Safety net only — Version should be set during sprint planning.
+# This catches issues that slipped through without a Version tag.
+#
+# Safeguard: only stamps issues closed AFTER the previous release
+# of the same repo. Prevents old un-versioned issues from being
+# incorrectly attributed to the current release.
+#
+# Version format: strips 'v' prefix from tag (v2.18.0 → 2.18.0).
+# Must match an existing Version option in the project field.
+#
+# Authentication: GitHub App (ilm-project-bot)
+# Trigger: GitHub Release published on any org repo
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  stamp-version:
+    runs-on: ubuntu-latest
+    steps:
+      # Generate a short-lived token from the GitHub App
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.ILM_PROJECT_BOT_APP_ID }}
+          private-key: ${{ secrets.ILM_PROJECT_BOT_PRIVATE_KEY }}
+          owner: OmnitrustILM
+
+      # Find Done issues without Version and stamp them
+      - name: Stamp Version on un-tagged Done issues
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          # --- Extract version from tag (strip 'v' prefix if present) ---
+          VERSION="${RELEASE_TAG#v}"
+          echo "Release version: $VERSION"
+          echo "Repository: $REPO"
+
+          # --- Get previous release date as lower bound ---
+          # Only stamp issues closed after this date to prevent
+          # attributing old issues to the wrong release.
+          PREV_RELEASE_DATE=$(gh api "repos/$REPO/releases" \
+            --jq '.[1].published_at // "2000-01-01T00:00:00Z"' 2>/dev/null)
+          echo "Previous release date: $PREV_RELEASE_DATE"
+
+          # --- Get Version field ID and target option ID ---
+          VERSION_FIELD=$(gh api graphql -f query='
+            { organization(login: "OmnitrustILM") {
+              projectV2(number: 5) {
+                field(name: "Version") {
+                  ... on ProjectV2SingleSelectField {
+                    id
+                    options { id name }
+                  }
+                }
+              }
+            } }' --jq '.data.organization.projectV2.field')
+
+          FIELD_ID=$(echo "$VERSION_FIELD" | jq -r '.id')
+          OPTION_ID=$(echo "$VERSION_FIELD" | jq -r ".options[] | select(.name == \"$VERSION\") | .id")
+
+          if [ -z "$OPTION_ID" ] || [ "$OPTION_ID" = "null" ]; then
+            echo "::warning::Version '$VERSION' not found in project field options. Add it to Project #5 settings first."
+            exit 0
+          fi
+
+          # --- Get closed issues in this repo, closed after previous release ---
+          ISSUES=$(gh issue list --repo "$REPO" --state closed \
+            --json number,url,closedAt --limit 200 \
+            --jq "[.[] | select(.closedAt > \"$PREV_RELEASE_DATE\")] | .[].url")
+
+          if [ -z "$ISSUES" ]; then
+            echo "No closed issues found after previous release."
+            exit 0
+          fi
+
+          STAMPED=0
+          SKIPPED=0
+
+          # --- Check each issue and stamp if Done + no Version ---
+          for issue_url in $ISSUES; do
+            # Get project item data
+            ITEM_DATA=$(gh api graphql -f query="
+              query(\$url: URI!) {
+                resource(url: \$url) {
+                  ... on Issue {
+                    projectItems(first: 5) {
+                      nodes {
+                        id
+                        project { id }
+                        fieldValues(first: 20) {
+                          nodes {
+                            ... on ProjectV2ItemFieldSingleSelectValue {
+                              field { ... on ProjectV2SingleSelectField { name } }
+                              name
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }" -f url="$issue_url" \
+              --jq '.data.resource.projectItems.nodes[] | select(.project.id == "PVT_kwDOB4ppKM4AlVOh")')
+
+            if [ -z "$ITEM_DATA" ]; then
+              continue  # Issue not in project
+            fi
+
+            # Check Status = Done and Version is empty
+            STATUS=$(echo "$ITEM_DATA" | jq -r \
+              '.fieldValues.nodes[] | select(.field.name == "Status") | .name')
+            EXISTING_VERSION=$(echo "$ITEM_DATA" | jq -r \
+              '.fieldValues.nodes[] | select(.field.name == "Version") | .name')
+
+            if [ "$STATUS" = "Done" ] && { [ -z "$EXISTING_VERSION" ] || [ "$EXISTING_VERSION" = "null" ]; }; then
+              ITEM_ID=$(echo "$ITEM_DATA" | jq -r '.id')
+
+              # Stamp the Version
+              gh api graphql -f query="
+                mutation {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: \"PVT_kwDOB4ppKM4AlVOh\"
+                    itemId: \"$ITEM_ID\"
+                    fieldId: \"$FIELD_ID\"
+                    value: { singleSelectOptionId: \"$OPTION_ID\" }
+                  }) {
+                    projectV2Item { id }
+                  }
+                }"
+              echo "Stamped $issue_url with Version $VERSION"
+              STAMPED=$((STAMPED + 1))
+            else
+              SKIPPED=$((SKIPPED + 1))
+            fi
+          done
+
+          # --- Summary ---
+          echo ""
+          echo "=== Post-Release Stamping Summary ==="
+          echo "Version: $VERSION"
+          echo "Issues stamped: $STAMPED"
+          echo "Issues skipped (already versioned or not Done): $SKIPPED"

--- a/.github/workflows/project-health-report.yml
+++ b/.github/workflows/project-health-report.yml
@@ -151,7 +151,7 @@ jobs:
           ERRORS=0
           WARNINGS=0
 
-          echo "$OPEN_ITEMS" | jq -c '.[]' | while IFS= read -r item; do
+          while IFS= read -r item; do
             ISSUE_TYPE=$(echo "$item" | jq -r '.content.issueType.name // "unknown"')
             REPO=$(echo "$item" | jq -r '.content.repository.name // "?"')
             NUM=$(echo "$item" | jq -r '.content.number // "?"')
@@ -184,7 +184,7 @@ jobs:
                 ERRORS=$((ERRORS + 1))
               fi
             fi
-          done
+          done < <(echo "$OPEN_ITEMS" | jq -c '.[]')
 
           echo "" >> "$REPORT"
 
@@ -203,7 +203,7 @@ jobs:
 
           NOW=$(date -u +%s)
 
-          echo "$OPEN_ITEMS" | jq -c '.[]' | while IFS= read -r item; do
+          while IFS= read -r item; do
             REPO=$(echo "$item" | jq -r '.content.repository.name // "?"')
             NUM=$(echo "$item" | jq -r '.content.number // "?"')
             TITLE=$(echo "$item" | jq -r '.content.title // "?" | .[0:60]')
@@ -239,7 +239,7 @@ jobs:
               echo "- **$REPO#$NUM** — In $STATUS for ~${AGE_DAYS}d (threshold: ${THRESHOLD}d) — $TITLE" >> "$REPORT"
               WARNINGS=$((WARNINGS + 1))
             fi
-          done
+          done < <(echo "$OPEN_ITEMS" | jq -c '.[]')
 
           echo "" >> "$REPORT"
           echo "---" >> "$REPORT"

--- a/.github/workflows/project-health-report.yml
+++ b/.github/workflows/project-health-report.yml
@@ -1,0 +1,257 @@
+name: Project Health Report
+
+# Generates a project health report as a GHA artifact.
+# Evaluates open issues in Project #5 against triage rules:
+# - Missing required fields (Severity, AC, etc.)
+# - Staleness (issues stuck in a status past threshold)
+# - Status distribution per Version
+#
+# Report only — does not auto-fix anything.
+# The /project-triage skill provides the interactive version
+# with auto-fix offers.
+#
+# Output: Markdown report uploaded as GHA artifact.
+#
+# Authentication: GitHub App (ilm-project-bot)
+# Trigger: weekly Monday 5:00 UTC, or manual dispatch
+
+on:
+  schedule:
+    - cron: '0 5 * * 1'  # Monday 5:00 UTC
+  workflow_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Generate a short-lived token from the GitHub App
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.ILM_PROJECT_BOT_APP_ID }}
+          private-key: ${{ secrets.ILM_PROJECT_BOT_PRIVATE_KEY }}
+          owner: OmnitrustILM
+
+      # Install yq for parsing triage rules config
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      # Fetch project data and generate health report
+      - name: Generate health report
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          REPORT="report.md"
+          echo "# Project Health Report — $(date -u +%Y-%m-%d)" > "$REPORT"
+          echo "" >> "$REPORT"
+          echo "Generated at: $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$REPORT"
+          echo "" >> "$REPORT"
+
+          # --- Fetch all open project items (paginated) ---
+          echo "Fetching project items..."
+          ALL_ITEMS="[]"
+          HAS_NEXT=true
+          CURSOR=""
+
+          while [ "$HAS_NEXT" = "true" ]; do
+            if [ -n "$CURSOR" ]; then
+              AFTER="after: \"$CURSOR\","
+            else
+              AFTER=""
+            fi
+
+            RESULT=$(gh api graphql -f query="
+              { organization(login: \"OmnitrustILM\") {
+                projectV2(number: 5) {
+                  items(first: 100, $AFTER) {
+                    nodes {
+                      content {
+                        ... on Issue {
+                          number title url state
+                          repository { name }
+                          createdAt
+                          assignees(first: 3) { nodes { login } }
+                          issueType { name }
+                        }
+                      }
+                      fieldValues(first: 20) {
+                        nodes {
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            field { ... on ProjectV2SingleSelectField { name } }
+                            name
+                          }
+                          ... on ProjectV2ItemFieldNumberValue {
+                            field { ... on ProjectV2Field { name } }
+                            number
+                          }
+                        }
+                      }
+                    }
+                    pageInfo { hasNextPage endCursor }
+                  }
+                }
+              } }")
+
+            # Extract items and merge
+            PAGE_ITEMS=$(echo "$RESULT" | jq '.data.organization.projectV2.items.nodes')
+            ALL_ITEMS=$(echo "$ALL_ITEMS $PAGE_ITEMS" | jq -s 'add')
+
+            HAS_NEXT=$(echo "$RESULT" | jq -r '.data.organization.projectV2.items.pageInfo.hasNextPage')
+            CURSOR=$(echo "$RESULT" | jq -r '.data.organization.projectV2.items.pageInfo.endCursor')
+          done
+
+          # --- Filter to open issues only ---
+          OPEN_ITEMS=$(echo "$ALL_ITEMS" | jq '[.[] | select(.content.state == "OPEN")]')
+          TOTAL=$(echo "$OPEN_ITEMS" | jq 'length')
+          echo "Total open issues: $TOTAL"
+
+          echo "## Summary" >> "$REPORT"
+          echo "" >> "$REPORT"
+          echo "Total open issues in Project #5: **$TOTAL**" >> "$REPORT"
+          echo "" >> "$REPORT"
+
+          # --- Status distribution ---
+          echo "## Status Distribution" >> "$REPORT"
+          echo "" >> "$REPORT"
+          echo "| Status | Count |" >> "$REPORT"
+          echo "|---|---|" >> "$REPORT"
+          echo "$OPEN_ITEMS" | jq -r '
+            [.[] | .fieldValues.nodes[] | select(.field.name == "Status") | .name]
+            | group_by(.) | map({status: .[0], count: length})
+            | sort_by(.status)
+            | .[] | "| \(.status) | \(.count) |"' >> "$REPORT"
+          echo "" >> "$REPORT"
+
+          # --- Version distribution ---
+          echo "## Version Distribution" >> "$REPORT"
+          echo "" >> "$REPORT"
+          echo "| Version | Count |" >> "$REPORT"
+          echo "|---|---|" >> "$REPORT"
+          echo "$OPEN_ITEMS" | jq -r '
+            [.[] | (.fieldValues.nodes[] | select(.field.name == "Version") | .name) // "Unversioned"]
+            | group_by(.) | map({version: .[0], count: length})
+            | sort_by(.version)
+            | .[] | "| \(.version) | \(.count) |"' >> "$REPORT"
+          echo "" >> "$REPORT"
+
+          # --- Missing required fields ---
+          echo "## Missing Required Fields (Errors)" >> "$REPORT"
+          echo "" >> "$REPORT"
+
+          # Helper: get field value for an item
+          get_field() {
+            echo "$1" | jq -r ".fieldValues.nodes[] | select(.field.name == \"$2\") | .name // empty"
+          }
+
+          ERRORS=0
+          WARNINGS=0
+
+          echo "$OPEN_ITEMS" | jq -c '.[]' | while IFS= read -r item; do
+            ISSUE_TYPE=$(echo "$item" | jq -r '.content.issueType.name // "unknown"')
+            REPO=$(echo "$item" | jq -r '.content.repository.name // "?"')
+            NUM=$(echo "$item" | jq -r '.content.number // "?"')
+            TITLE=$(echo "$item" | jq -r '.content.title // "?" | .[0:60]')
+            STATUS=$(get_field "$item" "Status")
+
+            # Bug: requires Severity
+            if [ "$ISSUE_TYPE" = "Bug" ]; then
+              SEVERITY=$(get_field "$item" "Severity")
+              if [ -z "$SEVERITY" ]; then
+                echo "- **$REPO#$NUM** — Bug missing Severity — $TITLE" >> "$REPORT"
+                ERRORS=$((ERRORS + 1))
+              fi
+            fi
+
+            # Release: requires Version
+            if [ "$ISSUE_TYPE" = "Release" ]; then
+              VERSION=$(get_field "$item" "Version")
+              if [ -z "$VERSION" ]; then
+                echo "- **$REPO#$NUM** — Release missing Version — $TITLE" >> "$REPORT"
+                ERRORS=$((ERRORS + 1))
+              fi
+            fi
+
+            # Epic past Planning: requires Complexity, Estimate, Start/End Date
+            if [ "$ISSUE_TYPE" = "Epic" ] && [ "$STATUS" != "Planning" ]; then
+              COMPLEXITY=$(get_field "$item" "Complexity")
+              if [ -z "$COMPLEXITY" ]; then
+                echo "- **$REPO#$NUM** — Epic past Planning missing Complexity — $TITLE" >> "$REPORT"
+                ERRORS=$((ERRORS + 1))
+              fi
+            fi
+          done
+
+          echo "" >> "$REPORT"
+
+          # --- Staleness check ---
+          echo "## Staleness Warnings" >> "$REPORT"
+          echo "" >> "$REPORT"
+
+          # Read thresholds from config
+          PLANNING_DAYS=$(yq eval '.staleness_thresholds.planning_days' project-triage-rules.yml)
+          ANALYSIS_DAYS=$(yq eval '.staleness_thresholds.analysis_days' project-triage-rules.yml)
+          OPEN_ASSIGNED_DAYS=$(yq eval '.staleness_thresholds.open_assigned_days' project-triage-rules.yml)
+          OPEN_UNASSIGNED_DAYS=$(yq eval '.staleness_thresholds.open_unassigned_days' project-triage-rules.yml)
+          IN_PROGRESS_DAYS=$(yq eval '.staleness_thresholds.in_progress_days' project-triage-rules.yml)
+          REVIEW_DAYS=$(yq eval '.staleness_thresholds.review_days' project-triage-rules.yml)
+          TESTING_DAYS=$(yq eval '.staleness_thresholds.testing_days' project-triage-rules.yml)
+
+          NOW=$(date -u +%s)
+
+          echo "$OPEN_ITEMS" | jq -c '.[]' | while IFS= read -r item; do
+            REPO=$(echo "$item" | jq -r '.content.repository.name // "?"')
+            NUM=$(echo "$item" | jq -r '.content.number // "?"')
+            TITLE=$(echo "$item" | jq -r '.content.title // "?" | .[0:60]')
+            CREATED=$(echo "$item" | jq -r '.content.createdAt // empty')
+            STATUS=$(get_field "$item" "Status")
+            ASSIGNEES=$(echo "$item" | jq -r '.content.assignees.nodes[].login // empty' 2>/dev/null)
+
+            if [ -z "$CREATED" ]; then
+              continue
+            fi
+
+            # Calculate age in days (uses createdAt as proxy for status entry)
+            CREATED_TS=$(date -u -d "$CREATED" +%s 2>/dev/null || echo "0")
+            AGE_DAYS=$(( (NOW - CREATED_TS) / 86400 ))
+
+            THRESHOLD=0
+            case "$STATUS" in
+              Planning) THRESHOLD=$PLANNING_DAYS ;;
+              Analysis) THRESHOLD=$ANALYSIS_DAYS ;;
+              Open)
+                if [ -n "$ASSIGNEES" ]; then
+                  THRESHOLD=$OPEN_ASSIGNED_DAYS
+                else
+                  THRESHOLD=$OPEN_UNASSIGNED_DAYS
+                fi
+                ;;
+              "In Progress") THRESHOLD=$IN_PROGRESS_DAYS ;;
+              Review) THRESHOLD=$REVIEW_DAYS ;;
+              Testing) THRESHOLD=$TESTING_DAYS ;;
+            esac
+
+            if [ "$THRESHOLD" -gt 0 ] && [ "$AGE_DAYS" -gt "$THRESHOLD" ]; then
+              echo "- **$REPO#$NUM** — In $STATUS for ~${AGE_DAYS}d (threshold: ${THRESHOLD}d) — $TITLE" >> "$REPORT"
+              WARNINGS=$((WARNINGS + 1))
+            fi
+          done
+
+          echo "" >> "$REPORT"
+          echo "---" >> "$REPORT"
+          echo "" >> "$REPORT"
+          echo "*Report generated by project-health-report.yml*" >> "$REPORT"
+
+          echo "Report generated: $(wc -l < "$REPORT") lines"
+
+      # Upload report as artifact (retained for 90 days)
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: project-health-report-${{ github.run_number }}
+          path: report.md
+          retention-days: 90

--- a/.github/workflows/reopen-tracking.yml
+++ b/.github/workflows/reopen-tracking.yml
@@ -51,11 +51,13 @@ jobs:
             --json assignees --jq '.assignees[].login' | tr '\n' ', ' | sed 's/,$//')
 
           # --- Post audit comment ---
-          COMMENT="**Issue reopened** by @${ACTOR}
-          Previously assigned to: ${ASSIGNEES:-none}
-          Reopened at: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+          read -r -d '' COMMENT <<COMMENT_EOF || true
+**Issue reopened** by @${ACTOR}
+Previously assigned to: ${ASSIGNEES:-none}
+Reopened at: $(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-          Please set the **Reopen Reason** field (Regression, Incomplete Implementation, Edge Case, Other)."
+Please set the **Reopen Reason** field (Regression, Incomplete Implementation, Edge Case, Other).
+COMMENT_EOF
 
           gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "$COMMENT"
           echo "Posted reopen comment on $REPO#$ISSUE_NUMBER"

--- a/.github/workflows/reopen-tracking.yml
+++ b/.github/workflows/reopen-tracking.yml
@@ -1,0 +1,107 @@
+name: Reopen Tracking
+
+# Posts an audit comment and clears the Reopen Reason field when
+# a previously closed issue is reopened (post-merge reopen).
+#
+# This fires ONLY on the GitHub `issues.reopened` event — meaning
+# the issue was Closed/Done and is now being reopened because a
+# problem was found after delivery (regression, missed requirement, etc.).
+#
+# This does NOT fire on pre-merge QA rejection. That's a status
+# regression (Testing → In Progress) on a still-open issue — no
+# GitHub reopen event occurs. Pre-merge QA rejection is a normal
+# review cycle, not a quality metric event.
+#
+# The built-in project workflow "Item reopened → In Progress"
+# handles the status transition. This workflow adds:
+# - Audit trail comment (who, when, previous assignee)
+# - Clears Reopen Reason (user must set new reason per methodics Section 2.7)
+#
+# Authentication: GitHub App (ilm-project-bot)
+# Trigger: issue reopened in any org repo
+
+on:
+  issues:
+    types: [reopened]
+
+jobs:
+  track-reopen:
+    runs-on: ubuntu-latest
+    steps:
+      # Generate a short-lived token from the GitHub App
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.ILM_PROJECT_BOT_APP_ID }}
+          private-key: ${{ secrets.ILM_PROJECT_BOT_PRIVATE_KEY }}
+          owner: OmnitrustILM
+
+      # Post audit comment and clear Reopen Reason field
+      - name: Post reopen comment and clear Reopen Reason
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          # --- Get previous assignees for context ---
+          ASSIGNEES=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" \
+            --json assignees --jq '.assignees[].login' | tr '\n' ', ' | sed 's/,$//')
+
+          # --- Post audit comment ---
+          COMMENT="**Issue reopened** by @${ACTOR}
+          Previously assigned to: ${ASSIGNEES:-none}
+          Reopened at: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          Please set the **Reopen Reason** field (Regression, Incomplete Implementation, Edge Case, Other)."
+
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "$COMMENT"
+          echo "Posted reopen comment on $REPO#$ISSUE_NUMBER"
+
+          # --- Clear Reopen Reason field on the project item ---
+          # Forces user to set a new reason for this specific reopen event.
+          # Old reason (if any) is stale and should not carry over.
+
+          ITEM_ID=$(gh api graphql -f query="
+            query(\$url: URI!) {
+              resource(url: \$url) {
+                ... on Issue {
+                  projectItems(first: 10) {
+                    nodes {
+                      id
+                      project { id }
+                    }
+                  }
+                }
+              }
+            }" -f url="$ISSUE_URL" \
+            --jq '.data.resource.projectItems.nodes[] | select(.project.id == "PVT_kwDOB4ppKM4AlVOh") | .id')
+
+          if [ -n "$ITEM_ID" ] && [ "$ITEM_ID" != "null" ]; then
+            # Get the Reopen Reason field ID
+            FIELD_ID=$(gh api graphql -f query='
+              { organization(login: "OmnitrustILM") {
+                projectV2(number: 5) {
+                  field(name: "Reopen Reason") {
+                    ... on ProjectV2SingleSelectField { id }
+                  }
+                }
+              } }' --jq '.data.organization.projectV2.field.id')
+
+            # Clear the field value
+            gh api graphql -f query="
+              mutation {
+                clearProjectV2ItemFieldValue(input: {
+                  projectId: \"PVT_kwDOB4ppKM4AlVOh\"
+                  itemId: \"$ITEM_ID\"
+                  fieldId: \"$FIELD_ID\"
+                }) {
+                  projectV2Item { id }
+                }
+              }"
+            echo "Cleared Reopen Reason field"
+          else
+            echo "::warning::Issue not found in project — Reopen Reason not cleared."
+          fi

--- a/.github/workflows/version-propagation.yml
+++ b/.github/workflows/version-propagation.yml
@@ -42,6 +42,9 @@ jobs:
           echo "Parent: $PARENT_URL"
           echo "Child: $CHILD_URL"
 
+          # Wait for auto-add-to-project to add the child to the project
+          sleep 5
+
           # --- Helper: get project item data for an issue ---
           get_project_item() {
             local url=$1

--- a/.github/workflows/version-propagation.yml
+++ b/.github/workflows/version-propagation.yml
@@ -1,0 +1,127 @@
+name: Version and Module Propagation
+
+# When a sub-issue is added to a parent, copies Version and Module
+# from parent to child — but only if the child's fields are empty.
+# Never overrides existing child values.
+#
+# Creation-time only: if the parent's Version/Module changes later,
+# children are NOT auto-updated. The "Version mismatch" consistency
+# rule (project-triage-rules.yml) catches drift for manual correction.
+#
+# Note: The sub_issues event is relatively new in GitHub. If not
+# available, version/module propagation must be done manually or
+# via the /epic-breakdown skill.
+#
+# Authentication: GitHub App (ilm-project-bot)
+# Trigger: sub-issue added to a parent issue
+
+on:
+  sub_issues:
+    types: [sub_issue_added]
+
+jobs:
+  propagate:
+    runs-on: ubuntu-latest
+    steps:
+      # Generate a short-lived token from the GitHub App
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.ILM_PROJECT_BOT_APP_ID }}
+          private-key: ${{ secrets.ILM_PROJECT_BOT_PRIVATE_KEY }}
+          owner: OmnitrustILM
+
+      # Copy Version and Module from parent to child if child's are empty
+      - name: Propagate fields from parent to child
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PARENT_URL: ${{ github.event.parent_issue.html_url }}
+          CHILD_URL: ${{ github.event.sub_issue.html_url }}
+        run: |
+          echo "Parent: $PARENT_URL"
+          echo "Child: $CHILD_URL"
+
+          # --- Helper: get project item data for an issue ---
+          get_project_item() {
+            local url=$1
+            gh api graphql -f query="
+              query(\$url: URI!) {
+                resource(url: \$url) {
+                  ... on Issue {
+                    projectItems(first: 10) {
+                      nodes {
+                        id
+                        project { id }
+                        fieldValues(first: 20) {
+                          nodes {
+                            ... on ProjectV2ItemFieldSingleSelectValue {
+                              field { ... on ProjectV2SingleSelectField { name } }
+                              name
+                              optionId
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }" -f url="$url" \
+              --jq '.data.resource.projectItems.nodes[] | select(.project.id == "PVT_kwDOB4ppKM4AlVOh")'
+          }
+
+          # Get project item data for parent and child
+          PARENT_ITEM=$(get_project_item "$PARENT_URL")
+          CHILD_ITEM=$(get_project_item "$CHILD_URL")
+
+          CHILD_ITEM_ID=$(echo "$CHILD_ITEM" | jq -r '.id')
+
+          if [ -z "$CHILD_ITEM_ID" ] || [ "$CHILD_ITEM_ID" = "null" ]; then
+            echo "::warning::Child issue not found in project. It may not have been added yet."
+            exit 0
+          fi
+
+          # --- For each field to propagate: Version, Module ---
+          for field_name in "Version" "Module"; do
+            # Get parent's option ID for this field
+            parent_option_id=$(echo "$PARENT_ITEM" | jq -r \
+              ".fieldValues.nodes[] | select(.field.name == \"$field_name\") | .optionId" 2>/dev/null)
+
+            # Get child's option ID for this field
+            child_option_id=$(echo "$CHILD_ITEM" | jq -r \
+              ".fieldValues.nodes[] | select(.field.name == \"$field_name\") | .optionId" 2>/dev/null)
+
+            # Only copy if parent has a value and child doesn't
+            if [ -n "$parent_option_id" ] && [ "$parent_option_id" != "null" ] && \
+               { [ -z "$child_option_id" ] || [ "$child_option_id" = "null" ]; }; then
+
+              # Get the field ID to use in the mutation
+              field_id=$(gh api graphql -f query="
+                { organization(login: \"OmnitrustILM\") {
+                  projectV2(number: 5) {
+                    field(name: \"$field_name\") {
+                      ... on ProjectV2SingleSelectField { id }
+                    }
+                  }
+                } }" --jq '.data.organization.projectV2.field.id')
+
+              # Set the child's field to the parent's value
+              gh api graphql -f query="
+                mutation {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: \"PVT_kwDOB4ppKM4AlVOh\"
+                    itemId: \"$CHILD_ITEM_ID\"
+                    fieldId: \"$field_id\"
+                    value: { singleSelectOptionId: \"$parent_option_id\" }
+                  }) {
+                    projectV2Item { id }
+                  }
+                }"
+
+              parent_value=$(echo "$PARENT_ITEM" | jq -r \
+                ".fieldValues.nodes[] | select(.field.name == \"$field_name\") | .name")
+              echo "Propagated $field_name: '$parent_value' from parent to child"
+            else
+              echo "$field_name: parent empty or child already set — skipping"
+            fi
+          done


### PR DESCRIPTION
6 GitHub Actions workflows for ILM project management:

- auto-add-to-project: adds new issues to Project #5, sets initial status
  (Bug → Analysis, others → Planning)
- auto-set-fields-from-form: parses Bug/Vulnerability/Release templates,
  sets Severity, Module, Version, Priority fields on project items
- version-propagation: copies Version and Module from parent to child
  when sub-issues are added (creation-time only, never overrides)
- reopen-tracking: posts audit comment and clears Reopen Reason field
  on post-merge issue reopens
- post-release-stamping: stamps Version on un-tagged Done issues when
  a GitHub Release is published (with time-window safeguard)
- project-health-report: weekly health report as GHA artifact evaluating
  triage rules (missing fields, staleness, status distribution)

All workflows use GitHub App authentication (ilm-project-bot) via
actions/create-github-app-token@v1.

Part of ILM project management redesign Phase 3.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>