### PR TITLE
Use canonical org-name casing OmniTrustILM everywhere

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Questions & Discussions
-    url: https://github.com/orgs/OmnitrustILM/discussions
+    url: https://github.com/orgs/OmniTrustILM/discussions
     about: Ask questions, propose ideas, or discuss the platform
   - name: Documentation
     url: https://docs.otilm.com

--- a/.github/actions/auto-add-to-project/action.yml
+++ b/.github/actions/auto-add-to-project/action.yml
@@ -18,7 +18,7 @@ runs:
       # pin to the latest specific release.
       uses: actions/add-to-project@v1.0.2
       with:
-        project-url: https://github.com/orgs/OmnitrustILM/projects/5
+        project-url: https://github.com/orgs/OmniTrustILM/projects/5
         github-token: ${{ inputs.github-token }}
 
     - name: Set initial status

--- a/.github/actions/auto-add-to-project/set-initial-status.sh
+++ b/.github/actions/auto-add-to-project/set-initial-status.sh
@@ -51,7 +51,7 @@ if [ -z "$ITEM_ID" ] || [ "$ITEM_ID" = "null" ]; then
 fi
 
 STATUS_FIELD=$(gh api graphql -f query='
-  { organization(login: "OmnitrustILM") {
+  { organization(login: "OmniTrustILM") {
     projectV2(number: 5) {
       field(name: "Status") {
         ... on ProjectV2SingleSelectField {

--- a/.github/actions/auto-set-fields-from-form/parse-and-set-fields.sh
+++ b/.github/actions/auto-set-fields-from-form/parse-and-set-fields.sh
@@ -91,7 +91,7 @@ set_field() {
   local field_data
   field_data=$(gh api graphql -f query='
     query($field_name: String!) {
-      organization(login: "OmnitrustILM") {
+      organization(login: "OmniTrustILM") {
         projectV2(number: 5) {
           field(name: $field_name) {
             ... on ProjectV2SingleSelectField {

--- a/.github/actions/post-release-stamping/stamp-versions.sh
+++ b/.github/actions/post-release-stamping/stamp-versions.sh
@@ -38,7 +38,7 @@ PREV_RELEASE_DATE=$(printf '%s' "$PREV_RELEASES" | jq -r '.[1].published_at // "
 echo "Previous release date: $PREV_RELEASE_DATE"
 
 VERSION_FIELD=$(gh api graphql -f query='
-  { organization(login: "OmnitrustILM") {
+  { organization(login: "OmniTrustILM") {
     projectV2(number: 5) {
       field(name: "Version") {
         ... on ProjectV2SingleSelectField {

--- a/.github/actions/reopen-tracking/post-comment-and-clear.sh
+++ b/.github/actions/reopen-tracking/post-comment-and-clear.sh
@@ -49,7 +49,7 @@ if [ -z "$ITEM_ID" ] || [ "$ITEM_ID" = "null" ]; then
 fi
 
 FIELD_ID=$(gh api graphql -f query='
-  { organization(login: "OmnitrustILM") {
+  { organization(login: "OmniTrustILM") {
     projectV2(number: 5) {
       field(name: "Reopen Reason") {
         ... on ProjectV2SingleSelectField { id }

--- a/.github/actions/version-propagation/propagate-from-parent.sh
+++ b/.github/actions/version-propagation/propagate-from-parent.sh
@@ -99,7 +99,7 @@ for field_name in "Version" "Module"; do
   if [ -n "$parent_option_id" ] && [ -z "$child_option_id" ]; then
     field_id=$(gh api graphql -f query='
       query($field_name: String!) {
-        organization(login: "OmnitrustILM") {
+        organization(login: "OmniTrustILM") {
           projectV2(number: 5) {
             field(name: $field_name) {
               ... on ProjectV2SingleSelectField { id }

--- a/.github/scripts/label-sync/sync-labels.sh
+++ b/.github/scripts/label-sync/sync-labels.sh
@@ -13,7 +13,7 @@ SYNCED=0
 
 # Hard cap detection: gh silently truncates at --limit.
 LIMIT=500
-repos=$(gh repo list OmnitrustILM --no-archived --limit "$LIMIT" --json name --jq '.[].name')
+repos=$(gh repo list OmniTrustILM --no-archived --limit "$LIMIT" --json name --jq '.[].name')
 repo_count=$(printf '%s\n' "$repos" | grep -c . || :)
 if [ "$repo_count" -ge "$LIMIT" ]; then
   echo "::error::Reached --limit $LIMIT on gh repo list. Raise the limit."
@@ -31,7 +31,7 @@ for repo in $repos; do
     description=$(printf '%s' "$line" | yq eval '.description' -)
 
     if gh label create "$name" \
-      --repo "OmnitrustILM/$repo" \
+      --repo "OmniTrustILM/$repo" \
       --color "$color" \
       --description "$description" \
       --force 2>&1; then

--- a/.github/scripts/project-health-report/generate-report.sh
+++ b/.github/scripts/project-health-report/generate-report.sh
@@ -33,7 +33,7 @@ while [ "$HAS_NEXT" = "true" ]; do
   if [ -n "$CURSOR" ]; then
     RESULT=$(gh api graphql -F cursor="$CURSOR" -f query='
       query($cursor: String!) {
-        organization(login: "OmnitrustILM") {
+        organization(login: "OmniTrustILM") {
           projectV2(number: 5) {
             items(first: 100, after: $cursor) {
               nodes {
@@ -67,7 +67,7 @@ while [ "$HAS_NEXT" = "true" ]; do
   else
     RESULT=$(gh api graphql -f query='
       {
-        organization(login: "OmnitrustILM") {
+        organization(login: "OmniTrustILM") {
           projectV2(number: 5) {
             items(first: 100) {
               nodes {

--- a/.github/scripts/release-yml-sync/open-sync-pr.sh
+++ b/.github/scripts/release-yml-sync/open-sync-pr.sh
@@ -63,9 +63,9 @@ fi
 # $STATUS is intentionally expanded.
 body_file=$(mktemp)
 cat > "$body_file" <<EOF
-Automated sync of \`.github/release.yml\` from the org template in OmnitrustILM/.github.
+Automated sync of \`.github/release.yml\` from the org template in OmniTrustILM/.github.
 
-Source workflow: [Release.yml Sync](https://github.com/OmnitrustILM/.github/actions/workflows/release-yml-sync.yml)
+Source workflow: [Release.yml Sync](https://github.com/OmniTrustILM/.github/actions/workflows/release-yml-sync.yml)
 Previous state: \`$STATUS\`
 
 Merge to adopt the shared release-notes categories. To opt out of future syncs, close this PR without merging — the workflow will respect that decision on subsequent runs.

--- a/.github/scripts/release-yml-sync/resolve-targets.sh
+++ b/.github/scripts/release-yml-sync/resolve-targets.sh
@@ -5,7 +5,7 @@
 # Writes: repos=<json array>, count=<int> to $GITHUB_OUTPUT
 #
 # Behavior:
-#   - "all" → every non-archived OmnitrustILM repo
+#   - "all" → every non-archived OmniTrustILM repo
 #   - comma-separated list → validates each name exists
 #   - always drops the .github repo itself (self-reference)
 set -euo pipefail
@@ -18,7 +18,7 @@ LIMIT=500
 # out, so actions/checkout@v4 would fail with "couldn't find remote
 # ref refs/heads/<base>"). They're not meaningful sync targets until
 # they have at least one commit.
-all_repos=$(gh repo list OmnitrustILM --no-archived --limit "$LIMIT" --json name,isEmpty \
+all_repos=$(gh repo list OmniTrustILM --no-archived --limit "$LIMIT" --json name,isEmpty \
   --jq '.[] | select(.isEmpty == false) | .name')
 repo_count=$(printf '%s\n' "$all_repos" | grep -c . || :)
 if [ "$repo_count" -ge "$LIMIT" ]; then
@@ -32,7 +32,7 @@ else
   candidates=$(printf '%s\n' "$TARGET_INPUT" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | grep -v '^$' || :)
   for r in $candidates; do
     if ! printf '%s\n' "$all_repos" | grep -qx "$r"; then
-      echo "::error::Repo '$r' not found in OmnitrustILM (or is archived)"
+      echo "::error::Repo '$r' not found in OmniTrustILM (or is archived)"
       exit 1
     fi
   done

--- a/.github/scripts/repo-template-sync/sync-all.sh
+++ b/.github/scripts/repo-template-sync/sync-all.sh
@@ -93,12 +93,12 @@ fi
 
 body_file=$(mktemp)
 {
-  echo "Automated alignment of this repo with the org templates in OmnitrustILM/.github."
+  echo "Automated alignment of this repo with the org templates in OmniTrustILM/.github."
   echo ""
   echo "Tasks this PR addresses:"
   sed 's/^-/  -/' "$summary_file"
   echo ""
-  echo "Source workflow: [Repo Template Sync](https://github.com/OmnitrustILM/.github/actions/workflows/repo-template-sync.yml)"
+  echo "Source workflow: [Repo Template Sync](https://github.com/OmniTrustILM/.github/actions/workflows/repo-template-sync.yml)"
   echo ""
   echo "To opt out of future syncs, close this PR without merging — the workflow will respect that decision on subsequent runs."
 } > "$body_file"

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           app-id: ${{ secrets.ILM_PROJECT_BOT_APP_ID }}
           private-key: ${{ secrets.ILM_PROJECT_BOT_PRIVATE_KEY }}
-          owner: OmnitrustILM
+          owner: OmniTrustILM
 
       - name: Install yq
         run: |

--- a/.github/workflows/project-health-report.yml
+++ b/.github/workflows/project-health-report.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           app-id: ${{ secrets.ILM_PROJECT_BOT_APP_ID }}
           private-key: ${{ secrets.ILM_PROJECT_BOT_PRIVATE_KEY }}
-          owner: OmnitrustILM
+          owner: OmniTrustILM
 
       - name: Install yq
         run: |

--- a/.github/workflows/release-yml-sync.yml
+++ b/.github/workflows/release-yml-sync.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           app-id: ${{ secrets.ILM_PROJECT_BOT_APP_ID }}
           private-key: ${{ secrets.ILM_PROJECT_BOT_PRIVATE_KEY }}
-          owner: OmnitrustILM
+          owner: OmniTrustILM
 
       - name: Resolve target repos
         id: resolve
@@ -74,7 +74,7 @@ jobs:
         with:
           app-id: ${{ secrets.ILM_PROJECT_BOT_APP_ID }}
           private-key: ${{ secrets.ILM_PROJECT_BOT_PRIVATE_KEY }}
-          owner: OmnitrustILM
+          owner: OmniTrustILM
           repositories: |
             ${{ matrix.repo }}
 
@@ -86,7 +86,7 @@ jobs:
       - name: Checkout target repo
         uses: actions/checkout@v4
         with:
-          repository: OmnitrustILM/${{ matrix.repo }}
+          repository: OmniTrustILM/${{ matrix.repo }}
           path: target
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1
@@ -101,7 +101,7 @@ jobs:
         if: ${{ !inputs.dry_run && steps.diff.outputs.status != 'IDENTICAL' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPO: OmnitrustILM/${{ matrix.repo }}
+          REPO: OmniTrustILM/${{ matrix.repo }}
           REPO_NAME: ${{ matrix.repo }}
           STATUS: ${{ steps.diff.outputs.status }}
         run: source/.github/scripts/release-yml-sync/open-sync-pr.sh

--- a/.github/workflows/repo-template-sync.yml
+++ b/.github/workflows/repo-template-sync.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           app-id: ${{ secrets.ILM_PROJECT_BOT_APP_ID }}
           private-key: ${{ secrets.ILM_PROJECT_BOT_PRIVATE_KEY }}
-          owner: OmnitrustILM
+          owner: OmniTrustILM
 
       # Reuse resolve-targets.sh from release-yml-sync — same
       # non-archived repo list, self-exclusion, validation logic.
@@ -75,7 +75,7 @@ jobs:
         with:
           app-id: ${{ secrets.ILM_PROJECT_BOT_APP_ID }}
           private-key: ${{ secrets.ILM_PROJECT_BOT_PRIVATE_KEY }}
-          owner: OmnitrustILM
+          owner: OmniTrustILM
           repositories: |
             ${{ matrix.repo }}
 
@@ -87,7 +87,7 @@ jobs:
       - name: Checkout target repo
         uses: actions/checkout@v4
         with:
-          repository: OmnitrustILM/${{ matrix.repo }}
+          repository: OmniTrustILM/${{ matrix.repo }}
           path: target
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1
@@ -102,7 +102,7 @@ jobs:
         if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPO: OmnitrustILM/${{ matrix.repo }}
+          REPO: OmniTrustILM/${{ matrix.repo }}
           REPO_NAME: ${{ matrix.repo }}
         run: source/.github/scripts/repo-template-sync/sync-all.sh
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,4 +87,4 @@ Release (called from `release-automation.yml` on `release.published`):
 - Platform docs: https://docs.otilm.com
 - Discussions: https://github.com/orgs/OmniTrustILM/discussions
 - Contact: ilm@omnitrust.com
-- Org name for API calls and authorization checks: `OmnitrustILM`
+- Org name for API calls and authorization checks: `OmniTrustILM`

--- a/config/project-triage-rules.yml
+++ b/config/project-triage-rules.yml
@@ -41,4 +41,4 @@ consistency_rules:
   epic_without_qa_sub_issue: true      # Warning: Epic has no Task+qa sub-issue
 
 # Organization whose members are authorized to create Release and Epic issues
-authorized_org: OmnitrustILM
+authorized_org: OmniTrustILM

--- a/templates/caller-workflows/issue-automation.yml
+++ b/templates/caller-workflows/issue-automation.yml
@@ -1,7 +1,7 @@
 name: Issue Automation
 
 # Org-wide issue automation — calls composite actions hosted in
-# OmnitrustILM/.github. Kept in sync by the repo-template-sync workflow.
+# OmniTrustILM/.github. Kept in sync by the repo-template-sync workflow.
 #
 # opened:   add issue to Project #5 → set form fields → propagate from parent
 # reopened: post audit comment, clear Reopen Reason field
@@ -43,7 +43,7 @@ jobs:
         with:
           app-id: ${{ secrets.ILM_PROJECT_BOT_APP_ID }}
           private-key: ${{ secrets.ILM_PROJECT_BOT_PRIVATE_KEY }}
-          owner: OmnitrustILM
+          owner: OmniTrustILM
           repositories: ${{ github.event.repository.name }}
 
       # Broad token — spans all installation repos. Only needed for
@@ -56,28 +56,28 @@ jobs:
         with:
           app-id: ${{ secrets.ILM_PROJECT_BOT_APP_ID }}
           private-key: ${{ secrets.ILM_PROJECT_BOT_PRIVATE_KEY }}
-          owner: OmnitrustILM
+          owner: OmniTrustILM
 
       - name: Add to project
         if: github.event.action == 'opened'
-        uses: OmnitrustILM/.github/.github/actions/auto-add-to-project@issue-automation-v1
+        uses: OmniTrustILM/.github/.github/actions/auto-add-to-project@issue-automation-v1
         with:
           github-token: ${{ steps.token-narrow.outputs.token }}
 
       - name: Set fields from form
         if: ${{ !cancelled() && github.event.action == 'opened' }}
-        uses: OmnitrustILM/.github/.github/actions/auto-set-fields-from-form@issue-automation-v1
+        uses: OmniTrustILM/.github/.github/actions/auto-set-fields-from-form@issue-automation-v1
         with:
           github-token: ${{ steps.token-narrow.outputs.token }}
 
       - name: Propagate fields from parent
         if: ${{ !cancelled() && github.event.action == 'opened' }}
-        uses: OmnitrustILM/.github/.github/actions/version-propagation@issue-automation-v1
+        uses: OmniTrustILM/.github/.github/actions/version-propagation@issue-automation-v1
         with:
           github-token: ${{ steps.token-broad.outputs.token }}
 
       - name: Post reopen comment and clear Reopen Reason
         if: github.event.action == 'reopened'
-        uses: OmnitrustILM/.github/.github/actions/reopen-tracking@issue-automation-v1
+        uses: OmniTrustILM/.github/.github/actions/reopen-tracking@issue-automation-v1
         with:
           github-token: ${{ steps.token-narrow.outputs.token }}

--- a/templates/caller-workflows/release-automation.yml
+++ b/templates/caller-workflows/release-automation.yml
@@ -1,7 +1,7 @@
 name: Release Automation
 
 # Org-wide release automation — calls the post-release-stamping
-# composite action hosted in OmnitrustILM/.github. Kept in sync by
+# composite action hosted in OmniTrustILM/.github. Kept in sync by
 # the repo-template-sync workflow.
 #
 # release.published (stable only — prereleases are skipped inside
@@ -29,10 +29,10 @@ jobs:
         with:
           app-id: ${{ secrets.ILM_PROJECT_BOT_APP_ID }}
           private-key: ${{ secrets.ILM_PROJECT_BOT_PRIVATE_KEY }}
-          owner: OmnitrustILM
+          owner: OmniTrustILM
           repositories: ${{ github.event.repository.name }}
 
       - name: Stamp Version on un-tagged Done issues
-        uses: OmnitrustILM/.github/.github/actions/post-release-stamping@release-automation-v1
+        uses: OmniTrustILM/.github/.github/actions/post-release-stamping@release-automation-v1
         with:
           github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Fixes a case-sensitivity bug in `actions/add-to-project` that caused the issue-automation workflow to silently create draft placeholder items in Project #5 instead of linking the real issues.

## Root cause

The canonical login for this org (as returned by GitHub's API) is `OmniTrustILM` (capital T). Our YAML, scripts, and docs used `OmnitrustILM` (lowercase t) throughout.

GitHub URL lookups are case-insensitive, so `owner: OmnitrustILM` on `actions/create-github-app-token` and `gh repo list OmnitrustILM` always worked. But `actions/add-to-project` does a **case-sensitive** string compare:

```typescript
// From actions/add-to-project@v1.0.2 source:
if (issueOwnerName === projectOwnerName) {
  core.info('Creating project item')         // real link
} else {
  core.info('Creating draft issue in project')  // draft placeholder ← our path
}
```

`issueOwnerName` (from API) was `OmniTrustILM`. Our `projectOwnerName` (parsed from the `project-url`) was `OmnitrustILM`. Mismatch → draft.

Observed on the pilot sandbox repo — `auto-add-to-project` reported success, but the subsequent `set-initial-status.sh` couldn't find the issue's project item and warned "Issue not found in project after polling."

## Change

Bulk replacement: `OmnitrustILM` → `OmniTrustILM` across 20 files, 40 occurrences. Affects:

- 5 composite actions under `.github/actions/`
- 6 workflow files under `.github/workflows/`
- 4 scripts under `.github/scripts/`
- 2 caller workflow templates under `templates/caller-workflows/`
- `CLAUDE.md`, `.github/ISSUE_TEMPLATE/config.yml`, `config/project-triage-rules.yml`

## Test plan

- [x] After merge, move the `issue-automation-v1` tag forward to the merge SHA
- [x] Open a test issue on the pilot sandbox — verify `auto-add-to-project` logs `Creating project item` (not `Creating draft issue in project`), and that `set-initial-status.sh` finds the item and sets Status successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)