### PR TITLE
Drop conventional-commit prefix from PR titles

### DIFF
--- a/.github/scripts/release-yml-sync/open-sync-pr.sh
+++ b/.github/scripts/release-yml-sync/open-sync-pr.sh
@@ -74,7 +74,7 @@ EOF
 url=$(gh pr create --repo "$REPO" \
   --head "$branch" \
   --base "$base" \
-  --title "chore: sync .github/release.yml from org template" \
+  --title "Sync .github/release.yml from org template" \
   --body-file "$body_file")
 echo "::notice::Opened $url"
 echo "### $REPO_NAME: OPENED $url" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/scripts/repo-template-sync/sync-all.sh
+++ b/.github/scripts/repo-template-sync/sync-all.sh
@@ -106,7 +106,7 @@ body_file=$(mktemp)
 url=$(gh pr create --repo "$REPO" \
   --head "$branch" \
   --base "$base" \
-  --title "chore: sync repo to org template" \
+  --title "Sync repo to org template" \
   --body-file "$body_file")
 
 echo "::notice::Opened $url"


### PR DESCRIPTION
## Summary

PR titles generated by `release-yml-sync` and `repo-template-sync` used the `chore:` prefix. Per org convention, PR titles are plain sentences — prefixes belong only in commit messages (where they feed the `release.yml` changelog categories).

## Changes

- `.github/scripts/release-yml-sync/open-sync-pr.sh` — PR title: `chore: sync .github/release.yml from org template` → `Sync .github/release.yml from org template`
- `.github/scripts/repo-template-sync/sync-all.sh` — PR title: `chore: sync repo to org template` → `Sync repo to org template`

Commit messages inside the same scripts keep their `chore:` prefix (intentional — drives changelog categorization).

## Test plan

- [x] After merge, move `issue-automation-v1` and `release-automation-v1` tags forward to the merge SHA
- [ ] Next `repo-template-sync` dispatch opens PRs with the corrected plain-sentence titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)