### PR TITLE
Add issue-template-cleanup workflow

### DIFF
--- a/.github/scripts/issue-template-cleanup/cleanup-templates.sh
+++ b/.github/scripts/issue-template-cleanup/cleanup-templates.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Delete the per-repo .github/ISSUE_TEMPLATE/ directory so the target
+# repo inherits the org templates from OmniTrustILM/.github instead.
+#
+# GitHub issue-template inheritance is all-or-nothing: a repo that has
+# ANY file in .github/ISSUE_TEMPLATE/ uses only those and ignores the
+# org repo's templates. This script removes the per-repo directory so
+# the org templates take effect.
+#
+# Expects the caller to have checked out:
+#   target/   — the target repo (where the PR will be opened)
+#
+# Reads: GH_TOKEN, REPO (owner/name), REPO_NAME, DRY_RUN (true|false)
+# Writes: notices + markdown summary to $GITHUB_STEP_SUMMARY
+#
+# Idempotency: stable branch `chore/cleanup-legacy-issue-templates`.
+# Maintainer opt-out: closed-unmerged PR on that branch → skip.
+set -euo pipefail
+
+cd target
+
+template_dir=".github/ISSUE_TEMPLATE"
+
+# Short-circuit: nothing to clean up.
+if [ ! -d "$template_dir" ]; then
+  {
+    echo "### $REPO_NAME: already clean (no $template_dir)"
+  } >> "$GITHUB_STEP_SUMMARY"
+  exit 0
+fi
+
+# List the files we would remove (for summary + dry-run).
+files=$(find "$template_dir" -type f | sort)
+file_count=$(printf '%s\n' "$files" | grep -c . || :)
+
+if [ "$DRY_RUN" = "true" ]; then
+  {
+    echo "### $REPO_NAME: $file_count files would be deleted (dry run)"
+    echo ""
+    echo '```'
+    printf '%s\n' "$files"
+    echo '```'
+  } >> "$GITHUB_STEP_SUMMARY"
+  exit 0
+fi
+
+# Real run — commit + push + PR.
+git config user.name "ilm-project-bot[bot]"
+git config user.email "ilm-project-bot[bot]@users.noreply.github.com"
+
+branch="chore/cleanup-legacy-issue-templates"
+base=$(gh repo view "$REPO" --json defaultBranchRef --jq .defaultBranchRef.name)
+
+# If the bot opened a PR from this branch and a maintainer closed it
+# without merging, don't reopen — that's the per-repo opt-out signal
+# (maintainer has intentional custom templates to preserve).
+closed_unmerged=$(gh pr list --repo "$REPO" --head "$branch" --state closed --limit 100 --json number,mergedAt \
+  --jq '[.[] | select(.mergedAt == null)] | length')
+if [ "$closed_unmerged" -gt 0 ]; then
+  echo "::notice::$REPO has a closed-unmerged cleanup PR on $branch — skipping (maintainer opted out)"
+  echo "### $REPO_NAME: SKIPPED (closed-unmerged PR — maintainer opted out)" >> "$GITHUB_STEP_SUMMARY"
+  exit 0
+fi
+
+git fetch origin "$base"
+# Fetch the sync branch if it exists — required for --force-with-lease.
+git fetch origin "$branch" 2>/dev/null || true
+git checkout -B "$branch" "origin/$base"
+
+git rm -r "$template_dir"
+
+if git diff --cached --quiet; then
+  # Shouldn't happen given the existence check at the top, but be safe.
+  echo "No changes after deletion — skipping $REPO"
+  echo "### $REPO_NAME: no changes" >> "$GITHUB_STEP_SUMMARY"
+  exit 0
+fi
+
+git commit -m "chore: remove legacy .github/ISSUE_TEMPLATE/ to inherit org templates"
+git push --force-with-lease origin "$branch"
+
+existing=$(gh pr list --repo "$REPO" --head "$branch" --state open --json number --jq '.[0].number // empty')
+if [ -n "$existing" ]; then
+  echo "::notice::Updated existing PR #$existing on $REPO"
+  echo "### $REPO_NAME: UPDATED PR #$existing ($file_count files removed)" >> "$GITHUB_STEP_SUMMARY"
+  exit 0
+fi
+
+body_file=$(mktemp)
+{
+  echo "This PR removes the per-repo issue templates under \`.github/ISSUE_TEMPLATE/\` so this repository inherits the canonical templates from \`OmniTrustILM/.github\`."
+  echo ""
+  echo "### Why"
+  echo ""
+  echo "GitHub issue-template inheritance is all-or-nothing: a repo that keeps any file in \`.github/ISSUE_TEMPLATE/\` uses only those files and ignores the org templates entirely. Removing the directory here lets the org's canonical template set (Bug, Feature, Epic, Task, QA, Documentation, Vulnerability, Release, plus \`config.yml\` for the chooser) take effect in this repo."
+  echo ""
+  echo "### Files removed ($file_count)"
+  echo ""
+  echo '```'
+  printf '%s\n' "$files"
+  echo '```'
+  echo ""
+  echo "### Opting out"
+  echo ""
+  echo "If this repo has an intentional custom template worth preserving, **close this PR without merging** — the cleanup workflow will respect that decision on future runs. Note that keeping any per-repo template means **none** of the org templates will be offered in this repo's New Issue picker."
+  echo ""
+  echo "Source workflow: [Issue Template Cleanup](https://github.com/OmniTrustILM/.github/actions/workflows/issue-template-cleanup.yml)"
+} > "$body_file"
+
+url=$(gh pr create --repo "$REPO" \
+  --head "$branch" \
+  --base "$base" \
+  --title "Remove legacy issue templates to inherit from org" \
+  --body-file "$body_file")
+
+echo "::notice::Opened $url"
+echo "### $REPO_NAME: OPENED $url ($file_count files removed)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/issue-template-cleanup.yml
+++ b/.github/workflows/issue-template-cleanup.yml
@@ -1,0 +1,119 @@
+name: Issue Template Cleanup
+
+# Removes the per-repo .github/ISSUE_TEMPLATE/ directory from target
+# repos so they inherit the org-wide issue templates from
+# OmniTrustILM/.github. Destructive task kept intentionally separate
+# from repo-template-sync (which is additive) so reviewer attention
+# isn't diluted.
+#
+# Self-excludes the .github repo itself (its ISSUE_TEMPLATE/ IS the
+# source of truth).
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_repos:
+        description: '"all" or comma-separated repo names'
+        required: true
+        default: "all"
+        type: string
+      dry_run:
+        description: "Dry run: report what would be deleted, open no PRs"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: issue-template-cleanup
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      repos: ${{ steps.resolve.outputs.repos }}
+      count: ${{ steps.resolve.outputs.count }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.ILM_PROJECT_BOT_APP_ID }}
+          private-key: ${{ secrets.ILM_PROJECT_BOT_PRIVATE_KEY }}
+          owner: OmniTrustILM
+
+      # Reuse resolve-targets.sh from release-yml-sync — same repo
+      # list resolution, self-exclusion of the .github repo, and
+      # comma-list validation.
+      - name: Resolve target repos
+        id: resolve
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TARGET_INPUT: ${{ inputs.target_repos }}
+        run: .github/scripts/release-yml-sync/resolve-targets.sh
+
+  cleanup:
+    needs: plan
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        repo: ${{ fromJSON(needs.plan.outputs.repos) }}
+    steps:
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.ILM_PROJECT_BOT_APP_ID }}
+          private-key: ${{ secrets.ILM_PROJECT_BOT_PRIVATE_KEY }}
+          owner: OmniTrustILM
+          repositories: |
+            ${{ matrix.repo }}
+
+      - name: Checkout .github (for scripts)
+        uses: actions/checkout@v4
+        with:
+          path: source
+
+      - name: Checkout target repo
+        uses: actions/checkout@v4
+        with:
+          repository: OmniTrustILM/${{ matrix.repo }}
+          path: target
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 1
+
+      - name: Cleanup legacy issue templates
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: OmniTrustILM/${{ matrix.repo }}
+          REPO_NAME: ${{ matrix.repo }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: source/.github/scripts/issue-template-cleanup/cleanup-templates.sh
+
+  summary:
+    needs: [plan, cleanup]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run summary
+        env:
+          TARGET_COUNT: ${{ needs.plan.outputs.count }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          CLEANUP_RESULT: ${{ needs.cleanup.result }}
+        run: |
+          {
+            echo "## Issue Template Cleanup — Final Summary"
+            echo ""
+            echo "Target repos: $TARGET_COUNT"
+            echo "Dry run: $DRY_RUN"
+            echo "Cleanup job aggregate: $CLEANUP_RESULT"
+            echo ""
+            echo "_Note: with fail-fast disabled, individual repos may have succeeded even if aggregate is 'failure'. See per-repo sections above._"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

New manual-dispatch workflow that removes each target repo's `.github/ISSUE_TEMPLATE/` directory so the repo inherits the canonical issue templates from `OmniTrustILM/.github`.

## Why

GitHub issue-template inheritance is **all-or-nothing**: a repo that keeps any file under `.github/ISSUE_TEMPLATE/` uses only those files and **ignores the org templates entirely**. Today 38 of our 63 non-archived repos carry the identical CZERTAINLY-era legacy set (7 `.md` files: `bug.md`, `change.md`, `epic.md`, `feature.md`, `task.md`, `user-story.md`, `vulnerability.md`) — pre-YAML-forms, pre-Module-field, and inconsistent with the canonical `.yml` forms we now publish from the org `.github` repo (Bug, Feature, Epic, Task, QA, Documentation, Vulnerability, Release + `config.yml` chooser).

## Why a separate workflow (not part of `repo-template-sync`)

`repo-template-sync` is **additive** (syncs release.yml + caller workflows). Deletion of per-repo templates is **destructive**: a maintainer reviewing a PR with additive changes is tempted to rubber-stamp the full PR without scrutinizing the file deletions. Keeping destructive and additive work in separate PRs keeps reviewer attention appropriately calibrated.

## Design

Same pattern as `release-yml-sync` / `repo-template-sync`:

- **Inputs:** `target_repos` (`"all"` or comma-separated list), `dry_run` (default `true`)
- **Plan** job resolves target repos, reusing `resolve-targets.sh` from `release-yml-sync` (same org-list, `.github` self-exclude, comma-list validation, empty-repo filter)
- **Cleanup** job: matrix fan-out (`max-parallel: 10`, `fail-fast: false`) per repo
- **Stable branch** `chore/cleanup-legacy-issue-templates`, `--force-with-lease` push (with pre-push branch fetch — same fix applied recently)
- **Maintainer opt-out** — closing the bot's cleanup PR without merging flags the repo as opt-out; subsequent runs skip it. This covers the case of a repo that intentionally keeps custom templates.
- **Self-excludes `OmniTrustILM/.github`** — its `ISSUE_TEMPLATE/` IS the source of truth; the resolve-targets script already drops it.
- **Dry-run default** is `true` — first run lists what would be deleted without touching any repo.

## Audit findings (pre-merge, informs the rollout)

39 repos have `.github/ISSUE_TEMPLATE/`:

- **38 have the identical legacy 7-template set** (all `.md` files). Content uniformity means no one customized — a blanket delete is safe without a hash-allowlist gate. Human review on each PR is the final safety net.
- **1 is `OmniTrustILM/.github` itself** (the 9 canonical `.yml` forms). Auto-excluded by `resolve-targets.sh`.

## Opt-out expectations

If a repo eventually wants a custom template:
- Close the cleanup PR without merging (workflow respects this on subsequent runs)
- After the cleanup PR is merged, adding any file back to `.github/ISSUE_TEMPLATE/` shadows **all** org templates — maintainers adding one custom template should copy the canonical ones too, and accept the drift burden

## Test plan

- [x] ShellCheck CI passes on the new script
- [x] Dispatch `issue-template-cleanup.yml` with `target_repos: interfaces, dry_run: true` — verify the step summary lists the 7 `.md` files that would be removed
- [x] Dispatch with `target_repos: interfaces, dry_run: false` — verify PR opens on `OmniTrustILM/interfaces`, review the PR body renders the opt-out instructions clearly
- [x] Merge the test PR, verify `New Issue` picker on `interfaces` now shows the org templates (Bug, Feature, Epic, Task, QA, Documentation, Vulnerability, Release)
- [x] Pilot batch of 3-5 repos with `dry_run: false`
- [ ] Full rollout: `target_repos: all, dry_run: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)