### PR TITLE
Refine issue template fields and placeholders

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -8,6 +8,7 @@ body:
     attributes:
       label: Description
       description: Clear description of the bug
+      placeholder: "The certificate detail page shows a blank renewal section when the authority is offline."
     validations:
       required: true
   - type: textarea
@@ -25,12 +26,14 @@ body:
     id: expected
     attributes:
       label: Expected Behavior
+      placeholder: "The renewal section shows the next-renewal date and a 'Renew now' button."
     validations:
       required: true
   - type: textarea
     id: actual
     attributes:
       label: Actual Behavior
+      placeholder: "The renewal section is blank with no error message — the operator has no way to act."
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -8,6 +8,7 @@ body:
     attributes:
       label: Description
       description: What documentation needs to be created or updated?
+      placeholder: "Add a Getting Started guide for new operators covering first login, profile setup, and dashboard tour."
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -24,22 +24,17 @@ body:
     validations:
       required: true
   - type: textarea
-    id: business-context
-    attributes:
-      label: Business Context
-      description: Why does this matter? Customer/market drivers, strategic alignment.
-    validations:
-      required: true
-  - type: textarea
     id: constraints
     attributes:
       label: Constraints
       description: Security, performance, backwards compatibility, regulatory requirements
+      placeholder: "Must keep existing keyboard shortcuts on the certificate detail page; cannot break the screen-reader flow."
   - type: textarea
     id: out-of-scope
     attributes:
       label: Out of Scope
       description: Explicitly what this Epic does NOT include
+      placeholder: "Mobile/responsive layout — handled in a separate Frontend Epic."
   - type: markdown
     attributes:
       value: "## Testing Scope"
@@ -56,6 +51,7 @@ body:
     attributes:
       label: Regression Risk
       description: Describe what existing functionality might break
+      placeholder: "The certificate detail page shares state management with the renewal wizard — both flows need regression QA."
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -8,6 +8,7 @@ body:
     attributes:
       label: Description
       description: What do you want to add or change?
+      placeholder: "Add a 'Bulk renew' action on the certificates inventory page."
     validations:
       required: true
   - type: textarea
@@ -20,7 +21,8 @@ body:
     id: use-case
     attributes:
       label: Use Case
-      description: Describe how this feature would be used
+      description: Concrete scenarios of how this feature would be used. Skip if the User Story already covers the usage.
+      placeholder: "Operator selects multiple expiring certificates from the inventory grid, clicks Bulk renew, and the action queues a renewal request for each."
   - type: textarea
     id: acceptance-criteria
     attributes:

--- a/.github/ISSUE_TEMPLATE/qa.yml
+++ b/.github/ISSUE_TEMPLATE/qa.yml
@@ -26,11 +26,11 @@ body:
       label: Test Scope
       description: What functionality or area does this cover?
   - type: textarea
-    id: test-scenarious
+    id: test-scenarios
     attributes:
-      label: Test Scenarious
+      label: Test Scenarios
       description: Step-by-step manual test scenarios. Each scenario should describe a concrete user action and expected result.
-      placeholder: |
+      value: |
         1. Open [page] → verify [expected]
         2. Perform [action] → verify [result]
   - type: input

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -7,6 +7,7 @@ body:
     attributes:
       label: Description
       description: What needs to be done?
+      placeholder: "Update the dashboard widget order — Certificates first, then Keys, then Discovery."
     validations:
       required: true
   - type: textarea
@@ -14,6 +15,6 @@ body:
     attributes:
       label: Definition of Done
       description: How do we know this task is complete?
-      placeholder: |
-        - [ ] ...
-        - [ ] ...
+      value: |
+        - [ ]
+        - [ ]

--- a/.github/ISSUE_TEMPLATE/vulnerability.yml
+++ b/.github/ISSUE_TEMPLATE/vulnerability.yml
@@ -26,6 +26,7 @@ body:
     attributes:
       label: Description
       description: What is the vulnerability and what is the impact?
+      placeholder: "Stored XSS in the certificate Description field — script executes when the certificate detail page is opened."
     validations:
       required: true
   - type: textarea
@@ -33,6 +34,7 @@ body:
     attributes:
       label: Affected Components
       description: Which services, images, or packages are affected?
+      placeholder: "Certificate detail page (fe-administrator); affects ILM 2.13.x and 2.14.x."
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
## Summary

- **Drop Business Context field from Epic.** The User Story's "so that [benefit]" already conveys the why; elaborate drivers fit in the User Story body or in Constraints.
- **Fix typo in QA template:** \`test-scenarious\` → \`test-scenarios\` (both \`id:\` and \`label:\`). Verified the id is not referenced elsewhere in workflows or scripts.
- **Add placeholders / pre-fill skeletons** across templates — most fields were blank, leaving form users staring at empty inputs. Examples lean on product-UI scenarios (certificate detail page, inventory, dashboard) for concreteness.

## Per-template changes

| File | Change |
|---|---|
| bug.yml | placeholders on Description, Expected, Actual |
| feature.yml | placeholder on Description; Use Case description tightened + placeholder added |
| task.yml | placeholder on Description; Definition of Done switched from \`placeholder:\` to \`value:\` |
| documentation.yml | placeholder on Description |
| vulnerability.yml | placeholders on Description, Affected Components |
| epic.yml | \`business-context\` block removed; placeholders on Constraints, Out of Scope, Regression Risk |
| qa.yml | \`test-scenarious\` → \`test-scenarios\`; Test Scenarios switched from \`placeholder:\` to \`value:\` |

## \`placeholder:\` vs \`value:\`

\`value:\` is editable pre-fill; \`placeholder:\` is ghost text. For required structured fields (Feature AC, Epic Use Cases, Bug Steps to Reproduce — already \`value:\`) we keep \`placeholder:\` to avoid the unedited skeleton satisfying \`required: true\`. For optional structured fields (Task DoD, QA Test Scenarios) \`value:\` is fine.

## Test plan

- [ ] Each template renders with the new hints
- [ ] Epic form has no Business Context section and submits cleanly
- [ ] QA form label reads "Test Scenarios" (no more typo)
- [ ] QA submissions still parse via \`auto-set-fields-from-form\` (field id changed)