### PR TITLE
Add Epic status consistency rules (§7.2, §7.3)

### DIFF
--- a/docs/development-process.md
+++ b/docs/development-process.md
@@ -689,6 +689,9 @@ Thresholds live in `config/project-triage-rules.yml` in the `.github` repo and c
 | Reopened without reason | Warning | Reopen Reason empty after reopen |
 | Release/Epic by non-org-member | Warning | Created by someone outside OmniTrustILM org |
 | Epic without Task+qa sub-issue | Warning | Epic has no QA/testing sub-issue — testing may be forgotten |
+| Epic status lags children | Warning | Epic is in Open but at least one child issue has a more advanced status (In Progress, Review, Testing). Epic should be moved to In Progress. |
+| Epic status ahead of children | Warning | Epic is in In Progress but all child issues are still in Open or Planning. Epic may have been moved prematurely. |
+| Epic Done with open children | Error | Epic Status = Done but at least one child issue is still open. All children must reach Done before the Epic can be marked Done. |
 
 ### 7.3 Rule precedence
 
@@ -698,6 +701,7 @@ When multiple rules fire on the same issue, resolve conflicts in this order:
 2. **Legitimate close reasons override "Closed but not Done".** An issue closed as `not planned` or `duplicate` is a valid terminal state — the "Closed but not Done" Warning does NOT fire for these closures.
 3. **"Done but Open state" takes precedence over "Closed but not Done".** If the Status says Done and the issue is still open, that's an automation failure — fix it before evaluating any other close-related rule.
 4. **Status transitions driven by automation always win over human-set status.** If a human sets Status = Done but the PR hasn't merged, the automation will re-enter the correct Status on the next relevant event. Don't manually force Status.
+5. **"Epic Done with open children" takes precedence over "Epic status ahead of children".** If the Epic is Done with open children, the Error is shown and the Warning is suppressed.
 
 If two Warnings fire on the same issue, the triage report shows both — no suppression; the operator resolves in any order.
 


### PR DESCRIPTION
## Summary

Adds three new consistency rules to §7.2 covering Epic status alignment with its child issues, and extends §7.3 with the corresponding rule precedence.

## Changes

### §7.2 Consistency rules — three new rules

| Rule | Severity | Description |
|---|---|---|
| Epic status lags children | Warning | Epic is in Open but at least one child issue has a more advanced status (In Progress, Review, Testing). Epic should be moved to In Progress. |
| Epic status ahead of children | Warning | Epic is in In Progress but all child issues are still in Open or Planning. Epic may have been moved prematurely. |
| Epic Done with open children | Error | Epic Status = Done but at least one child issue is still open. All children must reach Done before the Epic can be marked Done. |

### §7.3 Rule precedence — new item #5

> **"Epic Done with open children" takes precedence over "Epic status ahead of children".** If the Epic is Done with open children, the Error is shown and the Warning is suppressed.

## Motivation

The previous §7.2 did not cover the case where an Epic's status is inconsistent with the aggregate status of its child issues. This is a common PM oversight — an Epic remaining in Open while development has already started, or marked Done while children are still in progress. The new rules surface these cases in the weekly health report and `/project-triage` skill.

## Notes

- All three rules are aligned with the Epic lifecycle defined in §2.2 (transitions are manual for Epics).
- The two Warnings are informational — they do not block triage.
- The Error (`Epic Done with open children`) is a hard consistency violation — all children must be Done before the Epic can be.
