### PR TITLE
Publish manifest tags before signing them

### DIFF
--- a/.github/workflows/containers-build-and-push.yml
+++ b/.github/workflows/containers-build-and-push.yml
@@ -10,9 +10,11 @@ name: Publish Harbor image (reusable)
 #                                   a marker file.
 #   3. publish_manifest:            collects all per-arch digests, creates the
 #                                   multiarch manifest under each tag from
-#                                   docker/metadata-action, signs every digest
-#                                   and every tag with cosign, and pushes the
-#                                   repo README to the registry.
+#                                   docker/metadata-action, then signs every
+#                                   digest and every tag with cosign (tags are
+#                                   pushed before signing so a transient signing
+#                                   failure cannot leave tags unpublished), and
+#                                   pushes the repo README to the registry.
 #
 # Adding a new architecture later means adding one entry to the matrix - the
 # manifest job picks up any digests-* artifacts it finds.
@@ -275,25 +277,32 @@ jobs:
           echo "Per-arch digest files:"
           ls -1
 
-          # Build the source list of per-arch image references and sign each.
+          # Build the source list of per-arch image references.
           SOURCES=()
           for digest_file in *; do
-            ref="${IMAGE}@sha256:${digest_file}"
-            SOURCES+=("$ref")
-            echo "Signing per-arch image: $ref"
-            cosign sign --yes --key env://COSIGN_PRIVATE_KEY "$ref"
+            SOURCES+=("${IMAGE}@sha256:${digest_file}")
           done
 
           echo "Tags to publish:"
           echo "${TAGS}"
 
+          # Publish every manifest tag FIRST. 
           while IFS= read -r tag; do
             [ -z "$tag" ] && continue
             echo "Publishing manifest: $tag"
 
             docker buildx imagetools create --tag "$tag" "${SOURCES[@]}"
             docker buildx imagetools inspect "$tag"
+          done <<< "${TAGS}"
 
+          # Sign every per-arch digest and every tag AFTER publication.
+          for ref in "${SOURCES[@]}"; do
+            echo "Signing per-arch image: $ref"
+            cosign sign --yes --key env://COSIGN_PRIVATE_KEY "$ref"
+          done
+
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
             echo "Signing multiarch manifest tag: $tag"
             cosign sign --yes --key env://COSIGN_PRIVATE_KEY "$tag"
           done <<< "${TAGS}"


### PR DESCRIPTION
## Problem

The `publish_manifest` job in `containers-build-and-push.yml` signs every per-arch digest **first**, then creates and pushes the multiarch manifest tags. Because the step runs under `set -euo pipefail`, a signing failure aborts the step **before any tag is pushed**.

cosign uploads each signature to the public Rekor transparency log. A retried upload — after a transient network/timeout on a request that already landed server-side — returns `HTTP 409 createLogEntryConflict` ("an equivalent entry already exists"). That transient, re-runnable signing error is enough to leave `develop-latest` (and other tags) pointing at the **previous** build, silently shipping a stale image to consumers.

### Observed impact

A real occurrence: the `time-quality-monitor` publish for "Support Azure Service Bus (#17)" failed at the per-arch signing step with a Rekor `409` on a digest that had never been signed before (first attempt, ~30s retry/backoff window before the error). `develop-latest` was never re-pointed and kept serving the prior build — which broke a downstream Helm chart whose env-var contract matched the new, unpublished image.

## Fix

Reorder the step so **tag publication happens first** and **signing happens afterwards**:

1. Build the per-arch source list.
2. `docker buildx imagetools create --tag …` for every tag (publish).
3. `cosign sign` every per-arch digest and every tag.

A signing hiccup now surfaces as a re-runnable job failure **without holding back the published images**. Behavior on the happy path is unchanged: the same digests and tags get signed.

## Verification

- `yaml.safe_load` parses the workflow.
- `bash -n` on the rendered run-step script passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)