### PR TITLE
Fix create-issue crash on label-less types under bash 3.2

### DIFF
--- a/.claude/skills/create-issue/create.sh
+++ b/.claude/skills/create-issue/create.sh
@@ -103,7 +103,7 @@ ISSUE_URL=$(gh issue create \
   --repo "OmniTrustILM/$REPO" \
   --title "$TITLE" \
   --body-file "$BODY_FILE" \
-  "${LABEL_FLAGS[@]}") || fail "gh issue create failed (see stderr above)"
+  ${LABEL_FLAGS[@]+"${LABEL_FLAGS[@]}"}) || fail "gh issue create failed (see stderr above)"
 ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
 [ -n "$ISSUE_NUMBER" ] || fail "could not extract issue number from URL: $ISSUE_URL"
 ISSUE_NODE_ID=$(gh api "repos/OmniTrustILM/$REPO/issues/$ISSUE_NUMBER" --jq '.node_id')


### PR DESCRIPTION
## What

`create.sh` in the `create-issue` skill expanded `"${LABEL_FLAGS[@]}"` unconditionally. Under `set -u` in **bash 3.2** (the macOS system bash), expanding an empty array raises `unbound variable`, so `gh issue create` aborted before the issue was created — for **every label-less type**, which today means every **Task**.

Switched to the portable guard `${LABEL_FLAGS[@]+"${LABEL_FLAGS[@]}"}`.

## Why it's safe / multiplatform

- **bash 3.2 (macOS):** empty array now expands to nothing instead of erroring.
- **bash 4.4+ (Linux, Windows Git-Bash):** the empty-array-under-`set -u` case was already fixed upstream, so this is a no-op there — no regression.
- **Non-empty case:** the `word` part is `"${LABEL_FLAGS[@]}"`, so each element is still expanded individually and correctly quoted — multi-word labels are preserved.

Verified on bash 3.2: the original form fails with `a[@]: unbound variable`; the guarded form succeeds for both empty and non-empty arrays with quoting intact.

## How surfaced

Hit while creating a Task via `/create-issue` (OmniTrustILM/core#1645) — Task carries no default labels, so it triggered the empty-array path every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)